### PR TITLE
Add check for variable/method/class naming

### DIFF
--- a/src/main/java/tech/pegasys/tools/epchecks/JavaCase.java
+++ b/src/main/java/tech/pegasys/tools/epchecks/JavaCase.java
@@ -138,7 +138,7 @@ public class JavaCase extends BugChecker
 
   private static boolean isTestMethod(MethodTree tree) {
     for (AnnotationTree t : tree.getModifiers().getAnnotations()) {
-      if (t.getAnnotationType().toString().equals("Test")) {
+      if (t.getAnnotationType().toString().contains("Test")) {
         return true;
       }
     }

--- a/src/main/java/tech/pegasys/tools/epchecks/JavaCase.java
+++ b/src/main/java/tech/pegasys/tools/epchecks/JavaCase.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.tools.epchecks;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
+import static com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
+import static com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
+import static com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
+
+import java.util.regex.Pattern;
+import javax.lang.model.element.Modifier;
+
+import com.google.auto.service.AutoService;
+import com.google.common.base.CaseFormat;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.ModifiersTree;
+import com.sun.source.tree.VariableTree;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+    name = "JavaCase",
+    summary = "Use the appropriate case.",
+    severity = SUGGESTION,
+    linkType = BugPattern.LinkType.NONE)
+public class JavaCase extends BugChecker
+    implements MethodTreeMatcher, ClassTreeMatcher, VariableTreeMatcher {
+
+  private static Pattern CAMEL_CASE_PATTERN_LOWER =
+      Pattern.compile("^[a-z]+[A-Z0-9][a-z0-9]+[A-Za-z0-9]*$");
+  private static Pattern CAMEL_CASE_PATTERN_UPPER =
+      Pattern.compile("^[A-Z][a-z0-9]*[A-Z0-9][a-z0-9]+[A-Za-z0-9]*$");
+  private static Pattern UNDERSCORE_PATTERN_LOWER = Pattern.compile("^[A-Za-z0-9_]*$");
+  private static Pattern UNDERSCORE_PATTERN_UPPER = Pattern.compile("^[A-Z0-9_]*$");
+
+  @Override
+  public Description matchVariable(VariableTree tree, VisitorState state) {
+    String name = tree.getName().toString();
+    ModifiersTree modifiers = tree.getModifiers();
+    if (modifiers.getFlags().contains(Modifier.FINAL)) {
+      if (!isUpperUnderscoreCase(name)) {
+        return buildDescription(tree)
+            .addFix(SuggestedFixes.renameVariable(tree, toUpperUnderscore(name), state))
+            .build();
+      }
+    } else if (!isLowerCamelCase(name)) {
+      return buildDescription(tree)
+          .addFix(SuggestedFixes.renameVariable(tree, toCamelCaseLower(name), state))
+          .build();
+    }
+    return Description.NO_MATCH;
+  }
+
+  @Override
+  public Description matchMethod(MethodTree tree, VisitorState state) {
+    String name = tree.getName().toString();
+    if (!isLowerCamelCase(name)) {
+      return buildDescription(tree)
+          .addFix(SuggestedFixes.renameMethod(tree, toCamelCaseLower(name), state))
+          .build();
+    }
+    return Description.NO_MATCH;
+  }
+
+  @Override
+  public Description matchClass(ClassTree tree, VisitorState state) {
+    String name = tree.getSimpleName().toString();
+    if (!isUpperCamelCase(name)) {
+      String update = tree.toString().replace(name, toCamelCaseUpper(name));
+      update = update.split("\\r?\\n")[1];
+      return buildDescription(tree)
+          .addFix(SuggestedFix.builder().replace(tree, update).build())
+          .build();
+    }
+    return Description.NO_MATCH;
+  }
+
+  private static boolean isLowerCamelCase(String name) {
+    return CAMEL_CASE_PATTERN_LOWER.matcher(name).matches();
+  }
+
+  private static boolean isUpperCamelCase(String name) {
+    return CAMEL_CASE_PATTERN_UPPER.matcher(name).matches();
+  }
+
+  private static boolean isLowerUnderscoreCase(String name) {
+    return UNDERSCORE_PATTERN_LOWER.matcher(name).matches();
+  }
+
+  private static boolean isUpperUnderscoreCase(String name) {
+    return UNDERSCORE_PATTERN_UPPER.matcher(name).matches();
+  }
+
+  private static String toCamelCaseLower(String name) {
+    CaseFormat format = CaseFormat.LOWER_UNDERSCORE;
+    if (isUpperCamelCase(name)) format = CaseFormat.UPPER_CAMEL;
+    else if (isUpperUnderscoreCase(name)) format = CaseFormat.UPPER_UNDERSCORE;
+    return format.to(CaseFormat.LOWER_CAMEL, name);
+  }
+
+  private static String toCamelCaseUpper(String name) {
+    CaseFormat format = CaseFormat.LOWER_UNDERSCORE;
+    if (isLowerCamelCase(name)) format = CaseFormat.LOWER_CAMEL;
+    else if (isUpperUnderscoreCase(name)) format = CaseFormat.UPPER_UNDERSCORE;
+    return format.to(CaseFormat.UPPER_CAMEL, name);
+  }
+
+  private static String toUpperUnderscore(String name) {
+    CaseFormat format = CaseFormat.LOWER_UNDERSCORE;
+    if (isLowerCamelCase(name)) format = CaseFormat.LOWER_CAMEL;
+    else if (isUpperCamelCase(name)) format = CaseFormat.UPPER_CAMEL;
+    return format.to(CaseFormat.UPPER_UNDERSCORE, name);
+  }
+}

--- a/src/main/java/tech/pegasys/tools/epchecks/JavaCase.java
+++ b/src/main/java/tech/pegasys/tools/epchecks/JavaCase.java
@@ -171,8 +171,11 @@ public class JavaCase extends BugChecker
 
   private static String toUpperUnderscore(String name) {
     CaseFormat format = CaseFormat.LOWER_UNDERSCORE;
-    if (isLowerCamel(name)) format = CaseFormat.LOWER_CAMEL;
-    else if (isUpperCamel(name)) format = CaseFormat.UPPER_CAMEL;
+    if (isLowerCamel(name)) {
+      format = CaseFormat.LOWER_CAMEL;
+    } else if (isUpperCamel(name)) {
+      format = CaseFormat.UPPER_CAMEL;
+    }
     return format.to(CaseFormat.UPPER_UNDERSCORE, name);
   }
 }

--- a/src/main/java/tech/pegasys/tools/epchecks/JavaCase.java
+++ b/src/main/java/tech/pegasys/tools/epchecks/JavaCase.java
@@ -17,6 +17,7 @@ import static com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
 import static com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
 import static com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
 
+import java.util.Set;
 import java.util.regex.Pattern;
 import javax.lang.model.element.Modifier;
 
@@ -53,7 +54,8 @@ public class JavaCase extends BugChecker
   public Description matchVariable(VariableTree tree, VisitorState state) {
     String name = tree.getName().toString();
     ModifiersTree modifiers = tree.getModifiers();
-    if (modifiers.getFlags().contains(Modifier.FINAL)) {
+    Set<Modifier> flags = modifiers.getFlags();
+    if (flags.contains(Modifier.STATIC) && flags.contains(Modifier.FINAL)) {
       if (!isUpperUnderscore(name)) {
         return buildDescription(tree)
             .addFix(SuggestedFixes.renameVariable(tree, toUpperUnderscore(name), state))

--- a/src/main/java/tech/pegasys/tools/epchecks/JavaCase.java
+++ b/src/main/java/tech/pegasys/tools/epchecks/JavaCase.java
@@ -42,26 +42,26 @@ import com.sun.source.tree.VariableTree;
 public class JavaCase extends BugChecker
     implements MethodTreeMatcher, ClassTreeMatcher, VariableTreeMatcher {
 
-  private static Pattern CAMEL_CASE_PATTERN_LOWER =
+  private static Pattern PATTERN_LOWER_CAMEL =
       Pattern.compile("^[a-z]+[A-Z0-9][a-z0-9]+[A-Za-z0-9]*$");
-  private static Pattern CAMEL_CASE_PATTERN_UPPER =
+  private static Pattern PATTERN_UPPER_CAMEL =
       Pattern.compile("^[A-Z][a-z0-9]*[A-Z0-9][a-z0-9]+[A-Za-z0-9]*$");
-  private static Pattern UNDERSCORE_PATTERN_LOWER = Pattern.compile("^[A-Za-z0-9_]*$");
-  private static Pattern UNDERSCORE_PATTERN_UPPER = Pattern.compile("^[A-Z0-9_]*$");
+  private static Pattern PATTERN_LOWER_UNDERSCORE = Pattern.compile("^[A-Za-z0-9_]*$");
+  private static Pattern PATTERN_UPPER_UNDERSCORE = Pattern.compile("^[A-Z0-9_]*$");
 
   @Override
   public Description matchVariable(VariableTree tree, VisitorState state) {
     String name = tree.getName().toString();
     ModifiersTree modifiers = tree.getModifiers();
     if (modifiers.getFlags().contains(Modifier.FINAL)) {
-      if (!isUpperUnderscoreCase(name)) {
+      if (!isUpperUnderscore(name)) {
         return buildDescription(tree)
             .addFix(SuggestedFixes.renameVariable(tree, toUpperUnderscore(name), state))
             .build();
       }
-    } else if (!isLowerCamelCase(name)) {
+    } else if (!isLowerCamel(name)) {
       return buildDescription(tree)
-          .addFix(SuggestedFixes.renameVariable(tree, toCamelCaseLower(name), state))
+          .addFix(SuggestedFixes.renameVariable(tree, toLowerCamel(name), state))
           .build();
     }
     return Description.NO_MATCH;
@@ -70,9 +70,9 @@ public class JavaCase extends BugChecker
   @Override
   public Description matchMethod(MethodTree tree, VisitorState state) {
     String name = tree.getName().toString();
-    if (!isLowerCamelCase(name)) {
+    if (!isLowerCamel(name)) {
       return buildDescription(tree)
-          .addFix(SuggestedFixes.renameMethod(tree, toCamelCaseLower(name), state))
+          .addFix(SuggestedFixes.renameMethod(tree, toLowerCamel(name), state))
           .build();
     }
     return Description.NO_MATCH;
@@ -81,8 +81,8 @@ public class JavaCase extends BugChecker
   @Override
   public Description matchClass(ClassTree tree, VisitorState state) {
     String name = tree.getSimpleName().toString();
-    if (!isUpperCamelCase(name)) {
-      String update = tree.toString().replace(name, toCamelCaseUpper(name));
+    if (!isUpperCamel(name)) {
+      String update = tree.toString().replace(name, toUpperCamel(name));
       update = update.split("\\r?\\n")[1];
       return buildDescription(tree)
           .addFix(SuggestedFix.builder().replace(tree, update).build())
@@ -91,40 +91,40 @@ public class JavaCase extends BugChecker
     return Description.NO_MATCH;
   }
 
-  private static boolean isLowerCamelCase(String name) {
-    return CAMEL_CASE_PATTERN_LOWER.matcher(name).matches();
+  private static boolean isLowerCamel(String name) {
+    return PATTERN_LOWER_CAMEL.matcher(name).matches();
   }
 
-  private static boolean isUpperCamelCase(String name) {
-    return CAMEL_CASE_PATTERN_UPPER.matcher(name).matches();
+  private static boolean isUpperCamel(String name) {
+    return PATTERN_UPPER_CAMEL.matcher(name).matches();
   }
 
-  private static boolean isLowerUnderscoreCase(String name) {
-    return UNDERSCORE_PATTERN_LOWER.matcher(name).matches();
+  private static boolean isLowerUnderscore(String name) {
+    return PATTERN_LOWER_UNDERSCORE.matcher(name).matches();
   }
 
-  private static boolean isUpperUnderscoreCase(String name) {
-    return UNDERSCORE_PATTERN_UPPER.matcher(name).matches();
+  private static boolean isUpperUnderscore(String name) {
+    return PATTERN_UPPER_UNDERSCORE.matcher(name).matches();
   }
 
-  private static String toCamelCaseLower(String name) {
+  private static String toLowerCamel(String name) {
     CaseFormat format = CaseFormat.LOWER_UNDERSCORE;
-    if (isUpperCamelCase(name)) format = CaseFormat.UPPER_CAMEL;
-    else if (isUpperUnderscoreCase(name)) format = CaseFormat.UPPER_UNDERSCORE;
+    if (isUpperCamel(name)) format = CaseFormat.UPPER_CAMEL;
+    else if (isUpperUnderscore(name)) format = CaseFormat.UPPER_UNDERSCORE;
     return format.to(CaseFormat.LOWER_CAMEL, name);
   }
 
-  private static String toCamelCaseUpper(String name) {
+  private static String toUpperCamel(String name) {
     CaseFormat format = CaseFormat.LOWER_UNDERSCORE;
-    if (isLowerCamelCase(name)) format = CaseFormat.LOWER_CAMEL;
-    else if (isUpperUnderscoreCase(name)) format = CaseFormat.UPPER_UNDERSCORE;
+    if (isLowerCamel(name)) format = CaseFormat.LOWER_CAMEL;
+    else if (isUpperUnderscore(name)) format = CaseFormat.UPPER_UNDERSCORE;
     return format.to(CaseFormat.UPPER_CAMEL, name);
   }
 
   private static String toUpperUnderscore(String name) {
     CaseFormat format = CaseFormat.LOWER_UNDERSCORE;
-    if (isLowerCamelCase(name)) format = CaseFormat.LOWER_CAMEL;
-    else if (isUpperCamelCase(name)) format = CaseFormat.UPPER_CAMEL;
+    if (isLowerCamel(name)) format = CaseFormat.LOWER_CAMEL;
+    else if (isUpperCamel(name)) format = CaseFormat.UPPER_CAMEL;
     return format.to(CaseFormat.UPPER_UNDERSCORE, name);
   }
 }

--- a/src/test/java/tech/pegasys/tools/epchecks/JavaCaseTest.java
+++ b/src/test/java/tech/pegasys/tools/epchecks/JavaCaseTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.tools.epchecks;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class JavaCaseTest {
+
+  private CompilationTestHelper compilationHelper;
+
+  @BeforeEach
+  public void setup() {
+    compilationHelper = CompilationTestHelper.newInstance(JavaCase.class, getClass());
+  }
+
+  @Test
+  public void camelCasePositiveCases() {
+    compilationHelper.addSourceFile("JavaCasePositiveCases.java").doTest();
+  }
+
+  @Test
+  public void camelCaseNegativeCases() {
+    compilationHelper.addSourceFile("JavaCaseNegativeCases.java").doTest();
+  }
+}

--- a/src/test/resources/tech/pegasys/tools/epchecks/JavaCaseNegativeCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/JavaCaseNegativeCases.java
@@ -15,17 +15,56 @@
 
 package tech.pegasys.tools.epchecks;
 
+import java.util.Map;
+import java.util.LinkedHashMap;
+import org.junit.jupiter.api.Test;
+
 public class JavaCaseNegativeCases {
 
   public static final int PARAM_NAME = 1;
   public static int anotherParamName = 2;
   public final int finalButNotStatic = 3;
+  public final int myAST = 4;
 
   public void declaresValidVariable() {
     int paramName = 27;
   }
 
+  public void lower() {
+    int paramName = 28;
+  }
+
   public void hasValidParam(int paramName) {}
 
+  @Test
+  public void test_OneIsTwo() {}
+
   private class ValidClassName {}
+
+  private class Bytes8 {}
+
+  private class ValidClass {
+    int x;
+
+    public ValidClass() {
+      x = 5;
+    }
+  }
+
+  private class LRUCache {}
+
+  private class BLS {}
+
+  final class HasAnonymousClass<K, V> {
+    private final int maxSize = 10;
+    private <K, V> Map<K, V> createLimitedMap(final int maxSize) {
+      // Returns a new class
+      return new LinkedHashMap<>(16, 0.75f, true) {
+        @Override
+        protected boolean removeEldestEntry(final Map.Entry<K, V> eldest) {
+          return size() > maxSize;
+        }
+      };
+    }
+  }
 }

--- a/src/test/resources/tech/pegasys/tools/epchecks/JavaCaseNegativeCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/JavaCaseNegativeCases.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package tech.pegasys.tools.epchecks;
+
+public class JavaCaseNegativeCases {
+
+  public static final int PARAM_NAME = 1;
+  public static int anotherParamName = 4;
+
+  public void declaresValidVariable() {
+    int paramName = 27;
+  }
+
+  public void hasValidParam(int paramName) {}
+
+  private class ValidClassName {}
+}

--- a/src/test/resources/tech/pegasys/tools/epchecks/JavaCaseNegativeCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/JavaCaseNegativeCases.java
@@ -18,7 +18,8 @@ package tech.pegasys.tools.epchecks;
 public class JavaCaseNegativeCases {
 
   public static final int PARAM_NAME = 1;
-  public static int anotherParamName = 4;
+  public static int anotherParamName = 2;
+  public final int finalButNotStatic = 3;
 
   public void declaresValidVariable() {
     int paramName = 27;

--- a/src/test/resources/tech/pegasys/tools/epchecks/JavaCasePositiveCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/JavaCasePositiveCases.java
@@ -32,6 +32,9 @@ public class JavaCasePositiveCases {
   // BUG: Diagnostic contains: finalParamName
   public final int final_param_name = 5;
 
+  // BUG: Diagnostic contains: upper
+  private static Integer UPPER;
+
   public void declaresInvalidVariable() {
     // BUG: Diagnostic contains: paramName
     int param_name = 27;

--- a/src/test/resources/tech/pegasys/tools/epchecks/JavaCasePositiveCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/JavaCasePositiveCases.java
@@ -63,4 +63,15 @@ public class JavaCasePositiveCases {
 
   // BUG: Diagnostic contains: InvalidClassName
   private class INVALID_CLASS_NAME {}
+
+  private interface TestInterface {
+    // BUG: Diagnostic contains: NUMBER_ONE
+    int numberOne = 1;
+
+    // BUG: Diagnostic contains: NUMBER_TWO
+    int NumberTwo = 2;
+
+    // BUG: Diagnostic contains: NUMBER_THREE
+    int number_three = 3;
+  }
 }

--- a/src/test/resources/tech/pegasys/tools/epchecks/JavaCasePositiveCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/JavaCasePositiveCases.java
@@ -29,6 +29,9 @@ public class JavaCasePositiveCases {
   // BUG: Diagnostic contains: anotherParamName
   public static int another_param_name = 4;
 
+  // BUG: Diagnostic contains: finalParamName
+  public final int final_param_name = 5;
+
   public void declaresInvalidVariable() {
     // BUG: Diagnostic contains: paramName
     int param_name = 27;

--- a/src/test/resources/tech/pegasys/tools/epchecks/JavaCasePositiveCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/JavaCasePositiveCases.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package tech.pegasys.tools.epchecks;
+
+public class JavaCasePositiveCases {
+
+  // BUG: Diagnostic contains: PARAM_NAME
+  public static final int param_name = 1;
+
+  // BUG: Diagnostic contains: PARAM_NAME
+  public static final int paramName = 2;
+
+  // BUG: Diagnostic contains: PARAM_NAME
+  public static final int ParamName = 3;
+
+  // BUG: Diagnostic contains: anotherParamName
+  public static int another_param_name = 4;
+
+  public void declaresInvalidVariable() {
+    // BUG: Diagnostic contains: paramName
+    int param_name = 27;
+  }
+
+  // BUG: Diagnostic contains: invalidFuncName
+  public void invalid_func_name() {}
+
+  // BUG: Diagnostic contains: invalidFuncName
+  public void Invalid_Func_Name() {}
+
+  // BUG: Diagnostic contains: invalidFuncName
+  public void INVALID_FUNC_NAME() {}
+
+  // BUG: Diagnostic contains: paramName
+  public void hasInvalidParam(int param_name) {}
+
+  // BUG: Diagnostic contains: InvalidClassName
+  private class invalidClassName {}
+
+  // BUG: Diagnostic contains: InvalidClassName
+  private class Invalid_Class_Name {}
+
+  // BUG: Diagnostic contains: InvalidClassName
+  private class invalid_class_name {}
+
+  // BUG: Diagnostic contains: InvalidClassName
+  private class INVALID_CLASS_NAME {}
+}


### PR DESCRIPTION
This check will identify variables/methods/classes with improper naming. For example, if a class does not have an `UpperCamelCase` name or if a constant variable is not `ALL_UPPERCASE`.

A suggested variable name is provided for what I believe the author should use.

Fixes [#4519](https://github.com/ConsenSys/teku/issues/4519) for Teku.