### PR TITLE
Add MathTargetType check

### DIFF
--- a/src/main/java/tech/pegasys/tools/epchecks/MathTargetType.java
+++ b/src/main/java/tech/pegasys/tools/epchecks/MathTargetType.java
@@ -44,7 +44,7 @@ import com.sun.tools.javac.code.Type;
     linkType = BugPattern.LinkType.NONE)
 public class MathTargetType extends BugChecker implements MethodInvocationTreeMatcher {
 
-  // These are the math methods which multiple overloaded versions.
+  // These are the math methods with multiple overloaded versions.
   // There could be type confusion with these functions.
   private static final Matcher<ExpressionTree> POTENTIALLY_CONFUSED_MATH_FUNC =
       staticMethod()

--- a/src/main/java/tech/pegasys/tools/epchecks/MathTargetType.java
+++ b/src/main/java/tech/pegasys/tools/epchecks/MathTargetType.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.tools.epchecks;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Matchers.staticMethod;
+
+import javax.lang.model.type.TypeKind;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.AssignmentTree;
+import com.sun.source.tree.BinaryTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.ReturnTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.TypeCastTree;
+import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.code.Type;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+    name = "MathTargetType",
+    summary = "Neither of the Math function arguments are the same as the target type.",
+    severity = WARNING,
+    linkType = BugPattern.LinkType.NONE)
+public class MathTargetType extends BugChecker implements MethodInvocationTreeMatcher {
+
+  // These are the math methods which multiple overloaded versions.
+  // There could be type confusion with these functions.
+  private static final Matcher<ExpressionTree> POTENTIALLY_CONFUSED_MATH_FUNC =
+      staticMethod()
+          .onClass("java.lang.Math")
+          .namedAnyOf(
+              "min", "max", "addExact", "subtractExact", "multiplyExact", "floorDiv", "floorMod");
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (POTENTIALLY_CONFUSED_MATH_FUNC.matches(tree, state)) {
+      Tree parent = state.getPath().getParentPath().getLeaf();
+      Type type = getTargetType(tree, parent, state);
+      if (type != null && !anyMethodArgIs(tree, state, type.getKind())) {
+        String typeName = type.getKind().toString().toLowerCase();
+        return buildDescription(tree)
+            .setMessage(
+                "Neither of the function arguments are "
+                    + typeName
+                    + " types but the result is treated as such.")
+            .build();
+      }
+    }
+    return Description.NO_MATCH;
+  }
+
+  private boolean anyMethodArgIs(MethodInvocationTree tree, VisitorState state, TypeKind type) {
+    for (ExpressionTree t : tree.getArguments()) {
+      if (ASTHelpers.getType(t).getKind() == type) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private Type getTargetType(Tree original, Tree tree, VisitorState state) {
+    if (tree instanceof AssignmentTree) {
+      AssignmentTree assignmentTree = (AssignmentTree) tree;
+      return ASTHelpers.getType(assignmentTree.getVariable());
+    }
+
+    if (tree instanceof BinaryTree) {
+      // Need more information. Call again on parent.
+      Tree parent = state.getPath().getParentPath().getParentPath().getLeaf();
+      return getTargetType(original, parent, state);
+    }
+
+    if (tree instanceof MethodInvocationTree) {
+      MethodInvocationTree methodInvocationTree = (MethodInvocationTree) tree;
+      int index = methodInvocationTree.getArguments().indexOf(original);
+      return ASTHelpers.getSymbol(methodInvocationTree).params.get(index).type;
+    }
+
+    if (tree instanceof ReturnTree) {
+      Type type = null;
+      for (Tree parent : state.getPath()) {
+        switch (parent.getKind()) {
+          case METHOD:
+            MethodTree methodTree = (MethodTree) parent;
+            return ASTHelpers.getType(methodTree.getReturnType());
+          case LAMBDA_EXPRESSION:
+            Type parentType = ASTHelpers.getType(parent);
+            return state.getTypes().findDescriptorType(parentType).getReturnType();
+        }
+      }
+      return null;
+    }
+
+    if (tree instanceof TypeCastTree) {
+      TypeCastTree typeCastTree = (TypeCastTree) tree;
+      return ASTHelpers.getType(typeCastTree);
+    }
+
+    if (tree instanceof VariableTree) {
+      VariableTree variableTree = (VariableTree) tree;
+      return ASTHelpers.getType(variableTree);
+    }
+
+    System.out.println(tree);
+    return null;
+  }
+}

--- a/src/main/java/tech/pegasys/tools/epchecks/MathTargetType.java
+++ b/src/main/java/tech/pegasys/tools/epchecks/MathTargetType.java
@@ -122,7 +122,6 @@ public class MathTargetType extends BugChecker implements MethodInvocationTreeMa
       return ASTHelpers.getType(variableTree);
     }
 
-    System.out.println(tree);
     return null;
   }
 }

--- a/src/test/java/tech/pegasys/tools/epchecks/MathTargetTypeTest.java
+++ b/src/test/java/tech/pegasys/tools/epchecks/MathTargetTypeTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.tools.epchecks;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MathTargetTypeTest {
+
+  private CompilationTestHelper compilationHelper;
+
+  @BeforeEach
+  public void setup() {
+    compilationHelper = CompilationTestHelper.newInstance(MathTargetType.class, getClass());
+  }
+
+  @Test
+  public void mathTargetTypePositiveCases() {
+    compilationHelper.addSourceFile("MathTargetTypePositiveCases.java").doTest();
+  }
+
+  @Test
+  public void mathTargetTypeNegativeCases() {
+    compilationHelper.addSourceFile("MathTargetTypeNegativeCases.java").doTest();
+  }
+}

--- a/src/test/resources/tech/pegasys/tools/epchecks/MathTargetTypeNegativeCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/MathTargetTypeNegativeCases.java
@@ -17,8 +17,6 @@ package tech.pegasys.tools.epchecks;
 
 public class MathTargetTypeNegativeCases {
 
-    public void takesLong(int a, long b, int c) {}
-
     public void expectedInt() {
         int a = Math.min(0, 1);
     }

--- a/src/test/resources/tech/pegasys/tools/epchecks/MathTargetTypeNegativeCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/MathTargetTypeNegativeCases.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package tech.pegasys.tools.epchecks;
+
+public class MathTargetTypeNegativeCases {
+
+    public void takesLong(int a, long b, int c) {}
+
+    public void expectedInt() {
+        int a = Math.min(0, 1);
+    }
+
+    public void expectedLongOnlyOne() {
+        long a = Math.min(0L, 1);
+        long b = Math.min(0, 1L);
+    }
+
+    public void expectedLongBoth() {
+        long a = Math.min(0L, 1L);
+    }
+
+    public void expectedLongAssignment() {
+        long a;
+        a = Math.min(0L, 1L);
+    }
+
+    public void expectedIntAllFuncs() {
+        int a = Math.min(0, 1);
+        int b = Math.max(0, 1);
+        int c = Math.addExact(0, 1);
+        int e = Math.subtractExact(0, 1);
+        int d = Math.multiplyExact(0, 1);
+        int f = Math.floorDiv(0, 1);
+        int h = Math.floorMod(0, 1);
+    }
+
+    public void binaryOperations() {
+        int a = Math.min(0, 1) + 1;
+        int b = Math.min(0, 1) - 1;
+        int c = Math.min(0, 1) / 1;
+        int d = Math.min(0, 1) * 1;
+    }
+}

--- a/src/test/resources/tech/pegasys/tools/epchecks/MathTargetTypePositiveCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/MathTargetTypePositiveCases.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package tech.pegasys.tools.epchecks;
+
+public class MathTargetTypePositiveCases {
+
+    public void takesLong(int a, long b, int c) {}
+
+    public long expectedLong() {
+        // BUG: Diagnostic contains: Neither of the function arguments are long types
+        long a = Math.min(0, 1);
+        // BUG: Diagnostic contains: Neither of the function arguments are long types
+        a = (long) Math.min(0, 1);
+        // BUG: Diagnostic contains: Neither of the function arguments are long types
+        takesLong(0, Math.min(0, 1), 0);
+        // BUG: Diagnostic contains: Neither of the function arguments are long types
+        return Math.min(0, 1);
+    }
+
+    public void takesDouble(int a, double b, int c) {}
+
+    public double expectedDouble() {
+        // BUG: Diagnostic contains: Neither of the function arguments are double types
+        double a = Math.min(0, 1);
+        // BUG: Diagnostic contains: Neither of the function arguments are double types
+        a = (double) Math.min(0, 1);
+        // BUG: Diagnostic contains: Neither of the function arguments are double types
+        takesDouble(0, Math.min(0, 1), 0);
+        // BUG: Diagnostic contains: Neither of the function arguments are double types
+        return Math.min(0, 1);
+    }
+
+    public void takesFloat(int a, float b, int c) {}
+
+    public float expectedFloat() {
+        // BUG: Diagnostic contains: Neither of the function arguments are float types
+        float a = Math.min(0, 1);
+        // BUG: Diagnostic contains: Neither of the function arguments are float types
+        a = (float) Math.min(0, 1);
+        // BUG: Diagnostic contains: Neither of the function arguments are float types
+        takesFloat(0, Math.min(0, 1), 0);
+        // BUG: Diagnostic contains: Neither of the function arguments are float types
+        return Math.min(0, 1);
+    }
+
+    public void expectedLongAllFuncs() {
+        // BUG: Diagnostic contains: Neither of the function arguments are long types
+        long a = Math.min(0, 1);
+        // BUG: Diagnostic contains: Neither of the function arguments are long types
+        long b = Math.max(0, 1);
+        // BUG: Diagnostic contains: Neither of the function arguments are long types
+        long c = Math.addExact(0, 1);
+        // BUG: Diagnostic contains: Neither of the function arguments are long types
+        long e = Math.subtractExact(0, 1);
+        // BUG: Diagnostic contains: Neither of the function arguments are long types
+        long d = Math.multiplyExact(0, 1);
+        // BUG: Diagnostic contains: Neither of the function arguments are long types
+        long f = Math.floorDiv(0, 1);
+        // BUG: Diagnostic contains: Neither of the function arguments are long types
+        long h = Math.floorMod(0, 1);
+        // BUG: Diagnostic contains: Neither of the function arguments are long types
+        long i = Math.min(0, 1) + 1;
+        // BUG: Diagnostic contains: Neither of the function arguments are long types
+        long j = Math.min(0, 1) - 1;
+        // BUG: Diagnostic contains: Neither of the function arguments are long types
+        long k = Math.min(0, 1) / 1;
+        // BUG: Diagnostic contains: Neither of the function arguments are long types
+        long l = Math.min(0, 1) * 1;
+    }
+
+    public void expectedLongVars() {
+        int a = 0;
+        int b = 1;
+        // BUG: Diagnostic contains: Neither of the function arguments are long types
+        long c = Math.min(a, b);
+    }
+
+    public void expectedLongArgs(int a, int b) {
+        // BUG: Diagnostic contains: Neither of the function arguments are long types
+        long c = Math.min(a, b);
+    }
+}


### PR DESCRIPTION
This will identify calls to Math functions with overloaded parameters (`min`, `max`, `addExact`, `subtractExact`, `multiplyExact`, `floorDiv`, `floorMod`) where the input types are different than the result type. For example, if a long variable is set to the minimum of two ints. In this situation the result could just be an int. But it is possible that there was a mistake; for example `1` vs `1L`. The [IntLongMath](http://errorprone.info/bugpattern/IntLongMath) check is great about finding those, but doesn't handle this situation.

The inspiration for this check came from this fix:

```diff
- long leftNodesCount = Math.min(defaultNodesCount, 1 << (depth - 1));
+ long leftNodesCount = Math.min(defaultNodesCount, 1L << (depth - 1));
```

https://github.com/ConsenSys/teku/commit/42c4582118f662ffdbfb7977332c9c059f660e77#diff-3da59e58a3cd3e29e597722a32244fd7562529a8be88966d5512894819642265

I was confused to why the IntLongMath check didn't catch this. Because both of the arguments to `Math.min` are integers, the `Math.min(int, int) -> int` method is used, then casted to a long. The check didn't catch it because the argument is an integer type, not a long type.

In Teku, there are only a few findings, none of which look that important.

* https://github.com/ConsenSys/teku/blob/d470ef5ac75310af4d4d60fdb2128a5132ead2c4/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java#L175-L184
* https://github.com/ConsenSys/teku/blob/d470ef5ac75310af4d4d60fdb2128a5132ead2c4/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/config/GossipScoringConfigurator.java#L271-L272
* https://github.com/ConsenSys/teku/blob/ad5d0cef13bffe5596ebe140df805e7a3bf50933/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java#L62
* https://github.com/ConsenSys/teku/blob/ad5d0cef13bffe5596ebe140df805e7a3bf50933/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java#L85

I'm hoping this might help prevent future problems like this. 