### PR TITLE
Add ReturnsPrivateMutable check

### DIFF
--- a/src/main/java/tech/pegasys/tools/epchecks/JavaCase.java
+++ b/src/main/java/tech/pegasys/tools/epchecks/JavaCase.java
@@ -45,7 +45,6 @@ public class JavaCase extends BugChecker
     implements MethodTreeMatcher, ClassTreeMatcher, VariableTreeMatcher {
 
   private static final Pattern PATTERN_HAS_LOWER = Pattern.compile("^.*[a-z].*$");
-  private static final Pattern PATTERN_HAS_UPPER = Pattern.compile("^.*[A-Z].*$");
   private static final Pattern PATTERN_STARTS_WITH_LOWER = Pattern.compile("^[a-z].*$");
   private static final Pattern PATTERN_STARTS_WITH_UPPER = Pattern.compile("^[A-Z].*$");
   private static final Pattern PATTERN_UNDERSCORES = Pattern.compile("^_+$");

--- a/src/main/java/tech/pegasys/tools/epchecks/ReturnsPrivateMutable.java
+++ b/src/main/java/tech/pegasys/tools/epchecks/ReturnsPrivateMutable.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.tools.epchecks;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.Matchers.hasModifier;
+import static com.google.errorprone.matchers.Matchers.isInstanceField;
+import static com.google.errorprone.matchers.Matchers.methodHasVisibility;
+import static com.google.errorprone.matchers.Matchers.methodReturns;
+import static com.sun.source.tree.Tree.Kind.METHOD;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.lang.model.element.Modifier;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.matchers.MethodVisibility;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.ReturnTree;
+import com.sun.source.tree.Tree;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+    name = "ReturnsPrivateMutable",
+    summary = "Public method returns private field that can be modified.",
+    severity = SUGGESTION,
+    linkType = BugPattern.LinkType.NONE)
+public class ReturnsPrivateMutable extends BugChecker implements BugChecker.ReturnTreeMatcher {
+
+  // List of mutable types came from the WellKnownMutability bug pattern in error-prone. Removed
+  // java.lang.Object because Matchers::isSameType does not match the exact type; I think it
+  // checks if it is also a subtype.
+  public static final List<String> MUTABLE_TYPES =
+      List.of(
+          "com.google.common.collect.BiMap",
+          "com.google.common.collect.ListMultimap",
+          "com.google.common.collect.Multimap",
+          "com.google.common.collect.Multiset",
+          "com.google.common.collect.RangeMap",
+          "com.google.common.collect.RangeSet",
+          "com.google.common.collect.SetMultimap",
+          "com.google.common.collect.SortedMultiset",
+          "com.google.common.collect.Table",
+          "com.google.common.util.concurrent.AtomicDouble",
+          "com.google.protobuf.util.FieldMaskUtil.MergeOptions",
+          "java.lang.Iterable",
+          "java.text.DateFormat",
+          "java.util.ArrayList",
+          "java.util.BitSet",
+          "java.util.Calendar",
+          "java.util.Collection",
+          "java.util.EnumMap",
+          "java.util.EnumSet",
+          "java.util.HashMap",
+          "java.util.HashSet",
+          "java.util.List",
+          "java.util.Map",
+          "java.util.NavigableMap",
+          "java.util.NavigableSet",
+          "java.util.Random",
+          "java.util.Set",
+          "java.util.TreeMap",
+          "java.util.TreeSet",
+          "java.util.Vector",
+          "java.util.concurrent.atomic.AtomicBoolean",
+          "java.util.concurrent.atomic.AtomicLong",
+          "java.util.concurrent.atomic.AtomicReference",
+          "java.util.logging.Logger");
+
+  private static final Matcher<Tree> MUTABLE_TYPE =
+      anyOf(MUTABLE_TYPES.stream().map(Matchers::isSameType).collect(Collectors.toSet()));
+
+  private static final Matcher<ExpressionTree> PRIVATE_MUTABLE_INSTANCE_FIELD =
+      allOf(hasModifier(Modifier.PRIVATE), MUTABLE_TYPE, isInstanceField());
+
+  private static final Matcher<MethodTree> PUBLIC_METHOD_RETURNS_MUTABLE =
+      allOf(methodHasVisibility(MethodVisibility.Visibility.PUBLIC), methodReturns(MUTABLE_TYPE));
+
+  @Override
+  public Description matchReturn(ReturnTree tree, VisitorState state) {
+    // Filter out public/immutable fields.
+    ExpressionTree exp = tree.getExpression();
+    if (!PRIVATE_MUTABLE_INSTANCE_FIELD.matches(exp, state)) {
+      return NO_MATCH;
+    }
+
+    // Filter out non-public methods.
+    Tree maybeMethod = state.getPath().getParentPath().getParentPath().getLeaf();
+    if (maybeMethod.getKind() != METHOD) {
+      return NO_MATCH;
+    }
+    MethodTree method = (MethodTree) maybeMethod;
+    if (!PUBLIC_METHOD_RETURNS_MUTABLE.matches(method, state)) {
+      return NO_MATCH;
+    }
+
+    return buildDescription(tree)
+        .setMessage(
+            String.format(
+                "Public method (%s) returns mutable (%s) private field.",
+                method.getName(), method.getReturnType()))
+        .build();
+  }
+}

--- a/src/test/java/tech/pegasys/tools/epchecks/ReturnsPrivateMutableTest.java
+++ b/src/test/java/tech/pegasys/tools/epchecks/ReturnsPrivateMutableTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.tools.epchecks;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ReturnsPrivateMutableTest {
+
+  private CompilationTestHelper compilationHelper;
+
+  @BeforeEach
+  public void setup() {
+    compilationHelper = CompilationTestHelper.newInstance(ReturnsPrivateMutable.class, getClass());
+  }
+
+  @Test
+  public void returnsPrivateMutablePositiveCases() {
+    compilationHelper.addSourceFile("ReturnsPrivateMutablePositiveCases.java").doTest();
+  }
+
+  @Test
+  public void returnsPrivateMutableNegativeCases() {
+    compilationHelper.addSourceFile("ReturnsPrivateMutableNegativeCases.java").doTest();
+  }
+}

--- a/src/test/resources/tech/pegasys/tools/epchecks/ReturnsPrivateMutableNegativeCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/ReturnsPrivateMutableNegativeCases.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package tech.pegasys.tools.epchecks;
+
+import java.util.List;
+
+public class ReturnsPrivateMutableNegativeCases {
+  public List<Integer> publicMutable;
+  private List<Integer> privateMutable;
+  private Integer privateImmutable;
+
+  public List<Integer> getPublicMutable() {
+    return publicMutable;
+  }
+
+  private List<Integer> getPrivateMutablePrivate() {
+    return privateMutable;
+  }
+
+  public Integer getPrivateImmutable() {
+    return privateImmutable;
+  }
+}

--- a/src/test/resources/tech/pegasys/tools/epchecks/ReturnsPrivateMutablePositiveCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/ReturnsPrivateMutablePositiveCases.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package tech.pegasys.tools.epchecks;
+
+import java.util.List;
+
+public class ReturnsPrivateMutablePositiveCases {
+  private List<Integer> privateMutable;
+
+  public List<Integer> getPrivateMutablePublic() {
+    // BUG: Diagnostic contains: Public method
+    return privateMutable;
+  }
+
+  public List<Integer> anotherGetPrivateMutablePublic() {
+    // BUG: Diagnostic contains: Public method
+    return this.privateMutable;
+  }
+}


### PR DESCRIPTION
Proposing this new check. It identifies cases where a public method returns a private field that is mutable. In the spirit of defensive programming, I think we should point this out. The caller could (accidentally) modify the return value which would also modify the private field in the instance.

<details>
<summary>Findings in Teku (71)</summary>
Sorry for the super long lines, you'll need to scroll horizontally.

```
teku/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java:95: Note: [ReturnsPrivateMutable] Public method (getMetricsCategories) returns mutable (Set<MetricCategory>) private field.
teku/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java:99: Note: [ReturnsPrivateMutable] Public method (getMetricsHostAllowlist) returns mutable (List<String>) private field.
teku/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/DefaultAsyncRunnerFactory.java:38: Note: [ReturnsPrivateMutable] Public method (getAsyncRunners) returns mutable (Collection<AsyncRunner>) private field.
teku/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/StubAsyncRunnerFactory.java:36: Note: [ReturnsPrivateMutable] Public method (getStubAsyncRunners) returns mutable (List<StubAsyncRunner>) private field.
teku/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/TrackingUncaughtExceptionHandler.java:28: Note: [ReturnsPrivateMutable] Public method (getUncaughtExceptions) returns mutable (List<Throwable>) private field.
teku/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszContainerSchema.java:249: Note: [ReturnsPrivateMutable] Public method (getFieldSchemas) returns mutable (List<SszSchema<?>>) private field.
teku/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszContainerSchema.java:361: Note: [ReturnsPrivateMutable] Public method (getFieldNames) returns mutable (List<String>) private field.
teku/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/SszUnionSchemaImpl.java:135: Note: [ReturnsPrivateMutable] Public method (getChildrenSchemas) returns mutable (List<SszSchema<?>>) private field.
teku/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java:176: Note: [ReturnsPrivateMutable] Public method (getTags) returns mutable (List<String>) private field.
teku/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/ResponseMetadata.java:33: Note: [ReturnsPrivateMutable] Public method (getAdditionalHeaders) returns mutable (Map<String, String>) private field.
teku/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/AbstractSszMutablePrimitiveCollection.java:138: Note: [ReturnsPrivateMutable] Public method (getUpdates) returns mutable (List<PackedNodeUpdate<ElementT, SszElementT>>) private field.
teku/ethereum/pow/api/src/main/java/tech/pegasys/teku/ethereum/pow/api/DepositsFromBlockEvent.java:96: Note: [ReturnsPrivateMutable] Public method (getDeposits) returns mutable (List<Deposit>) private field.
teku/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/ValidatorStatuses.java:33: Note: [ReturnsPrivateMutable] Public method (getStatuses) returns mutable (List<ValidatorStatus>) private field.
teku/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java:213: Note: [ReturnsPrivateMutable] Public method (getRawConfig) returns mutable (Map<String, Object>) private field.
teku/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java:357: Note: [ReturnsPrivateMutable] Public method (getRequestedPowBlocks) returns mutable (Set<Bytes32>) private field.
teku/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java:162: Note: [ReturnsPrivateMutable] Public method (getDiscoveryBootnodes) returns mutable (List<String>) private field.
teku/storage/api/src/main/java/tech/pegasys/teku/storage/api/OnDiskStoreData.java:85: Note: [ReturnsPrivateMutable] Public method (getBlockInformation) returns mutable (Map<Bytes32, StoredBlockMetadata>) private field.
teku/storage/api/src/main/java/tech/pegasys/teku/storage/api/OnDiskStoreData.java:89: Note: [ReturnsPrivateMutable] Public method (getVotes) returns mutable (Map<UInt64, VoteTracker>) private field.
teku/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdate.java:91: Note: [ReturnsPrivateMutable] Public method (getHotBlocks) returns mutable (Map<Bytes32, BlockAndCheckpoints>) private field.
teku/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdate.java:95: Note: [ReturnsPrivateMutable] Public method (getHotStates) returns mutable (Map<Bytes32, BeaconState>) private field.
teku/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdate.java:99: Note: [ReturnsPrivateMutable] Public method (getDeletedHotBlocks) returns mutable (Set<Bytes32>) private field.
teku/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdate.java:129: Note: [ReturnsPrivateMutable] Public method (getStateRoots) returns mutable (Map<Bytes32, SlotAndBlockRoot>) private field.
teku/storage/api/src/main/java/tech/pegasys/teku/storage/api/FinalizedChainData.java:58: Note: [ReturnsPrivateMutable] Public method (getFinalizedChildToParentMap) returns mutable (Map<Bytes32, Bytes32>) private field.
teku/storage/api/src/main/java/tech/pegasys/teku/storage/api/FinalizedChainData.java:62: Note: [ReturnsPrivateMutable] Public method (getBlocks) returns mutable (Map<Bytes32, SignedBeaconBlock>) private field.
teku/storage/api/src/main/java/tech/pegasys/teku/storage/api/FinalizedChainData.java:66: Note: [ReturnsPrivateMutable] Public method (getStates) returns mutable (Map<Bytes32, BeaconState>) private field.
teku/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java:125: Note: [ReturnsPrivateMutable] Public method (getValidatorKeys) returns mutable (List<BLSKeyPair>) private field.
teku/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java:655: Note: [ReturnsPrivateMutable] Public method (getAttesterSlashings) returns mutable (List<AttesterSlashing>) private field.
teku/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/GetAllBlocksAtSlotResponse.java:28: Note: [ReturnsPrivateMutable] Public method (getData) returns mutable (Set<SignedBeaconBlockWithRoot>) private field.
teku/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/GetProposersDataResponse.java:32: Note: [ReturnsPrivateMutable] Public method (getData) returns mutable (Map<String, Object>) private field.
teku/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/GetProtoArrayResponse.java:30: Note: [ReturnsPrivateMutable] Public method (getData) returns mutable (List<Map<String, Object>>) private field.
teku/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/BlockHeadersResponse.java:41: Note: [ReturnsPrivateMutable] Public method (getData) returns mutable (List<BlockHeaderData>) private field.
teku/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/AllBlocksAtSlotData.java:45: Note: [ReturnsPrivateMutable] Public method (getBlocks) returns mutable (List<SignedBeaconBlock>) private field.
teku/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/ValidatorLivenessRequest.java:43: Note: [ReturnsPrivateMutable] Public method (getIndices) returns mutable (List<UInt64>) private field.
teku/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/StateSyncCommitteesData.java:31: Note: [ReturnsPrivateMutable] Public method (getValidators) returns mutable (List<UInt64>) private field.
teku/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/StateSyncCommitteesData.java:35: Note: [ReturnsPrivateMutable] Public method (getValidatorAggregates) returns mutable (List<List<UInt64>>) private field.
teku/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StateGenerationTaskTest.java:170: Note: [ReturnsPrivateMutable] Public method (getRequestedBlocks) returns mutable (Set<Bytes32>) private field.
teku/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/Eth1ProviderSelector.java:40: Note: [ReturnsPrivateMutable] Public method (getProviders) returns mutable (List<MonitorableEth1Provider>) private field.
teku/validator/api/src/main/java/tech/pegasys/teku/validator/api/AttesterDuties.java:44: Note: [ReturnsPrivateMutable] Public method (getDuties) returns mutable (List<AttesterDuty>) private field.
teku/validator/api/src/main/java/tech/pegasys/teku/validator/api/SyncCommitteeDuties.java:35: Note: [ReturnsPrivateMutable] Public method (getDuties) returns mutable (List<SyncCommitteeDuty>) private field.
teku/validator/api/src/main/java/tech/pegasys/teku/validator/api/ProposerDuties.java:41: Note: [ReturnsPrivateMutable] Public method (getDuties) returns mutable (List<ProposerDuty>) private field.
teku/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java:166: Note: [ReturnsPrivateMutable] Public method (getValidatorExternalSignerPublicKeySources) returns mutable (List<String>) private field.
teku/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java:207: Note: [ReturnsPrivateMutable] Public method (getValidatorKeys) returns mutable (List<String>) private field.
teku/beacon/pow/src/testFixtures/java/tech/pegasys/teku/beacon/pow/api/TrackingEth1EventsChannel.java:42: Note: [ReturnsPrivateMutable] Public method (getOrderedList) returns mutable (List<Object>) private field.
teku/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreTreeNodeStore.java:85: Note: [ReturnsPrivateMutable] Public method (getStoredBranchRoots) returns mutable (Collection<Bytes32>) private field.
teku/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java:117: Note: [ReturnsPrivateMutable] Public method (getNodes) returns mutable (List<ProtoNode>) private field.
teku/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/TrackingChainHeadChannel.java:60: Note: [ReturnsPrivateMutable] Public method (getHeadEvents) returns mutable (List<HeadEvent>) private field.
teku/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/TrackingChainHeadChannel.java:64: Note: [ReturnsPrivateMutable] Public method (getReorgEvents) returns mutable (List<ReorgEvent>) private field.
teku/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java:246: Note: [ReturnsPrivateMutable] Public method (getPreparedProposerInfo) returns mutable (Map<UInt64, PreparedProposerInfo>) private field.
teku/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java:250: Note: [ReturnsPrivateMutable] Public method (getValidatorRegistrationInfo) returns mutable (Map<UInt64, RegisteredValidatorInfo>) private field.
teku/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilder.java:82: Note: [ReturnsPrivateMutable] Public method (getIncludedAttestations) returns mutable (Collection<ValidateableAttestation>) private field.
teku/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java:368: Note: [ReturnsPrivateMutable] Public method (getValidatorKeys) returns mutable (List<BLSKeyPair>) private field.
teku/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/config/GossipTopicsScoringConfig.java:38: Note: [ReturnsPrivateMutable] Public method (getTopicConfigs) returns mutable (Map<String, GossipTopicScoringConfig>) private field.
teku/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/config/GossipScoringConfig.java:60: Note: [ReturnsPrivateMutable] Public method (getTopicScoringConfig) returns mutable (Map<String, GossipTopicScoringConfig>) private field.
teku/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryConfig.java:76: Note: [ReturnsPrivateMutable] Public method (getStaticPeers) returns mutable (List<String>) private field.
teku/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryConfig.java:80: Note: [ReturnsPrivateMutable] Public method (getBootnodes) returns mutable (List<String>) private field.
teku/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/jvmlibp2p/MockMessageApi.java:63: Note: [ReturnsPrivateMutable] Public method (getTopics) returns mutable (List<Topic>) private field.
teku/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java:355: Note: [ReturnsPrivateMutable] Public method (all) returns mutable (Collection<RpcMethod<?, ?, ?>>) private field.
teku/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/methods/VersionedEth2RpcMethod.java:97: Note: [ReturnsPrivateMutable] Public method (getIds) returns mutable (List<String>) private field.
teku/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java:100: Note: [ReturnsPrivateMutable] Public method (getBlocks) returns mutable (List<SignedBeaconBlock>) private field.
teku/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java:312: Note: [ReturnsPrivateMutable] Public method (complete) returns mutable (List<SignedBeaconBlock>) private field.
teku/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/SigningRequestBody.java:45: Note: [ReturnsPrivateMutable] Public method (getMetadata) returns mutable (Map<String, Object>) private field.
teku/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/schema/DeleteKeysResponse.java:32: Note: [ReturnsPrivateMutable] Public method (getData) returns mutable (List<DeleteKeyResult>) private field.
teku/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/schema/DeleteRemoteKeysResponse.java:30: Note: [ReturnsPrivateMutable] Public method (getData) returns mutable (List<DeleteKeyResult>) private field.
teku/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/attestations/ScheduledCommittee.java:50: Note: [ReturnsPrivateMutable] Public method (getValidators) returns mutable (List<ValidatorWithCommitteePositionAndIndex>) private field.
teku/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ProductionResult.java:125: Note: [ReturnsPrivateMutable] Public method (getValidatorPublicKeys) returns mutable (Set<BLSPublicKey>) private field.
teku/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorRestApiConfig.java:86: Note: [ReturnsPrivateMutable] Public method (getRestApiHostAllowlist) returns mutable (List<String>) private field.
teku/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorRestApiConfig.java:90: Note: [ReturnsPrivateMutable] Public method (getRestApiCorsAllowedOrigins) returns mutable (List<String>) private field.
teku/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/schema/PostKeysRequest.java:39: Note: [ReturnsPrivateMutable] Public method (getKeystores) returns mutable (List<String>) private field.
teku/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/schema/PostKeysRequest.java:47: Note: [ReturnsPrivateMutable] Public method (getPasswords) returns mutable (List<String>) private field.
teku/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/schema/PostRemoteKeysRequest.java:29: Note: [ReturnsPrivateMutable] Public method (getExternalValidators) returns mutable (List<ExternalValidator>) private field.
teku/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/schema/DeleteKeysRequest.java:26: Note: [ReturnsPrivateMutable] Public method (getPublicKeys) returns mutable (List<BLSPublicKey>) private field.
```

</details>

Thoughts?