### PR TITLE
Add new ReferenceComparison check

### DIFF
--- a/src/main/java/tech/pegasys/tools/epchecks/ReferenceComparison.java
+++ b/src/main/java/tech/pegasys/tools/epchecks/ReferenceComparison.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.tools.epchecks;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.BinaryTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.BinaryTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Type;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+    name = "ReferenceComparison",
+    summary = "Reference comparison should be value comparison",
+    severity = SUGGESTION,
+    linkType = BugPattern.LinkType.NONE)
+public class ReferenceComparison extends BugChecker implements BinaryTreeMatcher {
+  private static final Matcher<BinaryTree> EQUAL_OR_NOT_EQUAL =
+      Matchers.anyOf(Matchers.kindIs(Tree.Kind.EQUAL_TO), Matchers.kindIs(Tree.Kind.NOT_EQUAL_TO));
+  private static final Matcher<Tree> IS_ENUM = Matchers.isSubtypeOf("java.lang.Enum");
+
+  @Override
+  public Description matchBinary(BinaryTree tree, VisitorState state) {
+    if (!EQUAL_OR_NOT_EQUAL.matches(tree, state)) {
+      return Description.NO_MATCH;
+    }
+
+    Tree left = tree.getLeftOperand();
+    Tree right = tree.getRightOperand();
+    Type leftType = ASTHelpers.getType(left);
+    Type rightType = ASTHelpers.getType(right);
+
+    if (leftType == null || rightType == null) {
+      return Description.NO_MATCH;
+    }
+
+    // When a boxed type is compared to a primitive, it'll be unboxed.
+    if (leftType.isPrimitive() || rightType.isPrimitive()) {
+      return Description.NO_MATCH;
+    }
+
+    // Ignore null comparisons.
+    Matcher<Tree> isNull = Matchers.kindIs(Tree.Kind.NULL_LITERAL);
+    if (isNull.matches(left, state) || isNull.matches(right, state)) {
+      return Description.NO_MATCH;
+    }
+
+    // Ignore comparisons with "this" variables.
+    if (isThis(left) || isThis(right)) {
+      return Description.NO_MATCH;
+    }
+
+    // Ignore reference comparisons with enums. Those are a special case.
+    if (isEnum(left, state) || isEnum(right, state)) {
+      return Description.NO_MATCH;
+    }
+
+    // Ignore class comparisons, those are generally fine.
+    Matcher<Tree> isClass = Matchers.isSubtypeOf("java.lang.Class");
+    if (isClass.matches(left, state) || isClass.matches(right, state)) {
+      return Description.NO_MATCH;
+    }
+
+    return describeMatch(tree);
+  }
+
+  private static boolean isEnum(Tree tree, VisitorState state) {
+    Symbol symbol = ASTHelpers.getSymbol(tree);
+    if (symbol != null) {
+      if (symbol.isEnum()) {
+        return true;
+      }
+    }
+    return IS_ENUM.matches(tree, state);
+  }
+
+  private static boolean isThis(Tree tree) {
+    if (tree.getKind().equals(Tree.Kind.IDENTIFIER)) {
+      IdentifierTree identifier = (IdentifierTree) tree;
+      return identifier.getName().contentEquals("this");
+    }
+    return false;
+  }
+}

--- a/src/main/java/tech/pegasys/tools/epchecks/ReferenceComparison.java
+++ b/src/main/java/tech/pegasys/tools/epchecks/ReferenceComparison.java
@@ -36,8 +36,8 @@ import com.sun.tools.javac.code.Type;
 /**
  * This check is very similar to the <a
  * href=http://errorprone.info/bugpattern/ReferenceEquality>ReferenceEquality</a> check in Error
- * Prone. But this one identifies <code>Object</code> comparisons without an explicitly declared
- * <code>equals()</code> method.
+ * Prone. But this one identifies <code>Object</code> comparisons for types without an explicitly
+ * declared <code>equals()</code> method.
  */
 @AutoService(BugChecker.class)
 @BugPattern(

--- a/src/main/java/tech/pegasys/tools/epchecks/ReferenceComparison.java
+++ b/src/main/java/tech/pegasys/tools/epchecks/ReferenceComparison.java
@@ -33,6 +33,12 @@ import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Type;
 
+/**
+ * This check is very similar to the <a
+ * href=http://errorprone.info/bugpattern/ReferenceEquality>ReferenceEquality</a> check in Error
+ * Prone. But this one identifies <code>Object</code> comparisons without an explicitly declared
+ * <code>equals()</code> method.
+ */
 @AutoService(BugChecker.class)
 @BugPattern(
     name = "ReferenceComparison",
@@ -45,8 +51,9 @@ public class ReferenceComparison extends BugChecker implements BinaryTreeMatcher
 
   @Override
   public Description matchBinary(BinaryTree tree, VisitorState state) {
+    // We're looking for reference comparisons (== and !=).
     if (!EQUAL_OR_NOT_EQUAL.matches(tree, state)) {
-      return Description.NO_MATCH;
+      return NO_MATCH;
     }
 
     final Tree left = tree.getLeftOperand();
@@ -69,7 +76,7 @@ public class ReferenceComparison extends BugChecker implements BinaryTreeMatcher
       return NO_MATCH;
     }
 
-    // Ignore comparisons with "this" variables.
+    // Ignore comparisons with "this" identifier.
     if (isThis(left) || isThis(right)) {
       return NO_MATCH;
     }

--- a/src/main/java/tech/pegasys/tools/epchecks/ReferenceComparison.java
+++ b/src/main/java/tech/pegasys/tools/epchecks/ReferenceComparison.java
@@ -36,7 +36,7 @@ import com.sun.tools.javac.code.Type;
 @AutoService(BugChecker.class)
 @BugPattern(
     name = "ReferenceComparison",
-    summary = "Reference comparison should be value comparison",
+    summary = "Reference comparison should be value comparison.",
     severity = SUGGESTION,
     linkType = BugPattern.LinkType.NONE)
 public class ReferenceComparison extends BugChecker implements BinaryTreeMatcher {

--- a/src/test/java/tech/pegasys/tools/epchecks/ReferenceComparisonTest.java
+++ b/src/test/java/tech/pegasys/tools/epchecks/ReferenceComparisonTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.tools.epchecks;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ReferenceComparisonTest {
+
+  private CompilationTestHelper compilationHelper;
+
+  @BeforeEach
+  public void setup() {
+    compilationHelper = CompilationTestHelper.newInstance(ReferenceComparison.class, getClass());
+  }
+
+  @Test
+  public void referenceComparisonPositiveCases() {
+    compilationHelper.addSourceFile("ReferenceComparisonPositiveCases.java").doTest();
+  }
+
+  @Test
+  public void referenceComparisonNegativeCases() {
+    compilationHelper.addSourceFile("ReferenceComparisonNegativeCases.java").doTest();
+  }
+}

--- a/src/test/resources/tech/pegasys/tools/epchecks/ReferenceComparisonNegativeCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/ReferenceComparisonNegativeCases.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package tech.pegasys.tools.epchecks;
+
+import com.google.common.primitives.Bytes;
+import org.junit.Test;
+
+public class ReferenceComparisonNegativeCases {
+  public void comparisonWithEquals(final Bytes a, final Bytes b) {
+    if (a.equals(b)) {
+      System.out.println("they're the same");
+    }
+  }
+
+  public void comparisonWithEnums() {
+    if (TestEnum.A == TestEnum.B) {
+      System.out.println("they're the same");
+    }
+  }
+
+  public void comparisonWithEnumVariable(final TestEnum a) {
+    if (a == TestEnum.B) {
+      System.out.println("they're the same");
+    }
+  }
+
+  public void comparisonWithThis() {
+    Object o = null;
+    if (this == o) {
+      System.out.println("they're the same");
+    }
+  }
+
+  public void comparisonBoxedPrimitiveAndPrimitive(Integer a) {
+    if (a == 0) {
+      System.out.println("equals zero");
+    }
+    if (0 == a) {
+      System.out.println("equals zero");
+    }
+  }
+
+  public void comparisonWithEnumVariables(final TestEnum a, final TestEnum b) {
+    if (a == b) {
+      System.out.println("they're the same");
+    }
+  }
+
+  public void comparisonWithNull(final Bytes a) {
+    if (a == null) {
+      System.out.println("it's null");
+    }
+  }
+
+  public enum TestEnum {
+    A,
+    B,
+    C;
+  }
+}

--- a/src/test/resources/tech/pegasys/tools/epchecks/ReferenceComparisonNegativeCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/ReferenceComparisonNegativeCases.java
@@ -19,53 +19,40 @@ import com.google.common.primitives.Bytes;
 import org.junit.Test;
 
 public class ReferenceComparisonNegativeCases {
-  public void comparisonWithEquals(final Bytes a, final Bytes b) {
-    if (a.equals(b)) {
-      System.out.println("they're the same");
-    }
+  public boolean comparisonWithEquals(final Bytes a, final Bytes b) {
+    return a.equals(b);
   }
 
-  public void comparisonWithEnums() {
-    if (TestEnum.A == TestEnum.B) {
-      System.out.println("they're the same");
-    }
+  public boolean comparisonWithEnums() {
+    return TestEnum.A == TestEnum.B;
   }
 
-  public void comparisonWithEnumVariable(final TestEnum a) {
-    if (a == TestEnum.B) {
-      System.out.println("they're the same");
-    }
-  }
-
-  public void comparisonWithThis() {
+  public boolean comparisonWithThis() {
     Object o = null;
-    if (this == o) {
-      System.out.println("they're the same");
-    }
+    return this == o;
   }
 
-  public void comparisonBoxedPrimitiveAndPrimitive(Integer a) {
-    if (a == 0) {
-      System.out.println("equals zero");
-    }
-    if (0 == a) {
-      System.out.println("equals zero");
-    }
+  public boolean comparisonWithNull(final Bytes a) {
+    return a == null;
   }
 
-  public void comparisonWithEnumVariables(final TestEnum a, final TestEnum b) {
-    if (a == b) {
-      System.out.println("they're the same");
-    }
+  public boolean comparisonBoxedPrimitiveAndPrimitive(final Integer a) {
+    return a == 27;
   }
 
-  public void comparisonWithNull(final Bytes a) {
-    if (a == null) {
-      System.out.println("it's null");
-    }
+  public boolean comparisonWithGetClass(final Bytes a, final Bytes b) {
+    return a.getClass() == b.getClass();
   }
 
-  public enum TestEnum {
+  public boolean comparisonWithEnumVariable(final TestEnum a) {
+    return a == TestEnum.B;
+  }
+
+  public boolean comparisonWithEnumVariables(final TestEnum a, final TestEnum b) {
+    return a == b;
+  }
+
+  private enum TestEnum {
     A,
     B,
     C;

--- a/src/test/resources/tech/pegasys/tools/epchecks/ReferenceComparisonPositiveCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/ReferenceComparisonPositiveCases.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package tech.pegasys.tools.epchecks;
+
+import java.util.List;
+
+public class ReferenceComparisonPositiveCases {
+    public void comparisonWithIdentifiers(final List<Integer> a, final List<Integer> b) {
+    // BUG: Diagnostic contains: Reference comparison should be value comparison
+    if (a == b) {
+      System.out.println("they're the same");
+    }
+  }
+
+  public void comparisonWithIdentifierAndMethodInvocation(final List<Integer> a) {
+    // BUG: Diagnostic contains: Reference comparison should be value comparison
+    if (a == List.of(1, 2, 3)) {
+      System.out.println("they're the same");
+    }
+  }
+
+  public void comparisonWithMethodInvocationAndIdentifier(final List<Integer> b) {
+    // BUG: Diagnostic contains: Reference comparison should be value comparison
+    if (List.of(1, 2, 3) == b) {
+      System.out.println("they're the same");
+    }
+  }
+
+  public void comparisonWithMethodInvocations(final List<Integer> b) {
+    // BUG: Diagnostic contains: Reference comparison should be value comparison
+    if (List.of(1, 2, 3) == List.of(1, 2, 3, 4)) {
+      System.out.println("they're the same");
+    }
+  }
+}

--- a/src/test/resources/tech/pegasys/tools/epchecks/ReferenceComparisonPositiveCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/ReferenceComparisonPositiveCases.java
@@ -18,31 +18,50 @@ package tech.pegasys.tools.epchecks;
 import java.util.List;
 
 public class ReferenceComparisonPositiveCases {
-    public void comparisonWithIdentifiers(final List<Integer> a, final List<Integer> b) {
+  public void comparisonWithIdentifiers(final List<Integer> a, final List<Integer> b) {
     // BUG: Diagnostic contains: Reference comparison should be value comparison
     if (a == b) {
-      System.out.println("they're the same");
+      return;
     }
-  }
-
-  public void comparisonWithIdentifierAndMethodInvocation(final List<Integer> a) {
     // BUG: Diagnostic contains: Reference comparison should be value comparison
-    if (a == List.of(1, 2, 3)) {
-      System.out.println("they're the same");
+    if (a != b) {
+      return;
+    }
+    // BUG: Diagnostic contains: Reference comparison should be value comparison
+    if (b == a) {
+      return;
+    }
+    // BUG: Diagnostic contains: Reference comparison should be value comparison
+    if (b != a) {
+      return;
     }
   }
 
-  public void comparisonWithMethodInvocationAndIdentifier(final List<Integer> b) {
+  public boolean comparisonReturn(final List<Integer> a, final List<Integer> b) {
+    // BUG: Diagnostic contains: Reference comparison should be value comparison
+    return a == b;
+  }
+
+  public boolean comparisonReturnWithOr(final List<Integer> a, final List<Integer> b) {
+    // BUG: Diagnostic contains: Reference comparison should be value comparison
+    return false || a == b;
+  }
+
+  public void comparisonWithIdentifierAndMethodInvocationr(final List<Integer> b) {
     // BUG: Diagnostic contains: Reference comparison should be value comparison
     if (List.of(1, 2, 3) == b) {
-      System.out.println("they're the same");
+      return;
+    }
+    // BUG: Diagnostic contains: Reference comparison should be value comparison
+    if (b == List.of(1, 2, 3)) {
+      return;
     }
   }
 
   public void comparisonWithMethodInvocations(final List<Integer> b) {
     // BUG: Diagnostic contains: Reference comparison should be value comparison
     if (List.of(1, 2, 3) == List.of(1, 2, 3, 4)) {
-      System.out.println("they're the same");
+      return;
     }
   }
 }


### PR DESCRIPTION
Opening as a draft for initial feedback, in case this isn't something we want.

There are about two dozen false positives in Teku that are hard to ignore. Thoughts on these? There's a couple that may be actual issues (`validatorSyncCommitteeIndices` & `SimpleBranchNode#toString`), but they don't seem that important.

<details closed>
<summary>Findings in Teku</summary>

```
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/SerializableOneOfTypeDefinition.java:57: Note: [ReferenceComparison] Reference comparison should be value comparison
      if (current == type) {
                  ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java:237: Note: [ReferenceComparison] Reference comparison should be value comparison
                      if (completionException.getCause() != error) {
                                                         ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/SszUnionSchemaImpl.java:82: Note: [ReferenceComparison] Reference comparison should be value comparison
            .allMatch(schema -> schema != SszPrimitiveSchemas.NONE_SCHEMA),
                                       ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleBranchNode.java:81: Note: [ReferenceComparison] Reference comparison should be value comparison
    return left == right ? ("(2x " + left + ")") : ("(" + left + ", " + right + ')');
                ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszVectorSchema.java:170: Note: [ReferenceComparison] Reference comparison should be value comparison
    if (getElementSchema() == SszPrimitiveSchemas.BIT_SCHEMA) {
                           ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java:126: Note: [ReferenceComparison] Reference comparison should be value comparison
    if (getElementSchema() == SszPrimitiveSchemas.BIT_SCHEMA) {
                           ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java:137: Note: [ReferenceComparison] Reference comparison should be value comparison
    if (getElementSchema() == SszPrimitiveSchemas.BIT_SCHEMA) {
                           ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java:316: Note: [ReferenceComparison] Reference comparison should be value comparison
        .addBits(elementSchema == SszPrimitiveSchemas.BIT_SCHEMA ? 1 : 0)
                               ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszPrimitiveListSchema.java:41: Note: [ReferenceComparison] Reference comparison should be value comparison
    if (elementSchema == SszPrimitiveSchemas.BIT_SCHEMA) {
                      ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszPrimitiveListSchema.java:43: Note: [ReferenceComparison] Reference comparison should be value comparison
    } else if (elementSchema == SszPrimitiveSchemas.UINT64_SCHEMA) {
                             ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszPrimitiveListSchema.java:45: Note: [ReferenceComparison] Reference comparison should be value comparison
    } else if (elementSchema == SszPrimitiveSchemas.BYTE_SCHEMA) {
                             ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszPrimitiveListSchema.java:47: Note: [ReferenceComparison] Reference comparison should be value comparison
    } else if (elementSchema == SszPrimitiveSchemas.UINT8_SCHEMA) {
                             ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszByteListSchemaImpl.java:41: Note: [ReferenceComparison] Reference comparison should be value comparison
        elementSchema == SszPrimitiveSchemas.BYTE_SCHEMA
                      ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszPrimitiveVectorSchema.java:41: Note: [ReferenceComparison] Reference comparison should be value comparison
    if (elementSchema == SszPrimitiveSchemas.BIT_SCHEMA) {
                      ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszPrimitiveVectorSchema.java:43: Note: [ReferenceComparison] Reference comparison should be value comparison
    } else if (elementSchema == SszPrimitiveSchemas.BYTE_SCHEMA) {
                             ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszPrimitiveVectorSchema.java:46: Note: [ReferenceComparison] Reference comparison should be value comparison
    } else if (elementSchema == SszPrimitiveSchemas.UINT8_SCHEMA) {
                             ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszPrimitiveVectorSchema.java:49: Note: [ReferenceComparison] Reference comparison should be value comparison
    } else if (elementSchema == SszPrimitiveSchemas.BYTES32_SCHEMA) {
                             ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszByteVectorSchemaImpl.java:43: Note: [ReferenceComparison] Reference comparison should be value comparison
    return getElementSchema() == SszPrimitiveSchemas.BYTE_SCHEMA
                              ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/testFixtures/java/tech/pegasys/teku/infrastructure/ssz/RandomSszDataGenerator.java:78: Note: [ReferenceComparison] Reference comparison should be value comparison
      if (schema == SszPrimitiveSchemas.NONE_SCHEMA) {
                 ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/testFixtures/java/tech/pegasys/teku/infrastructure/ssz/RandomSszDataGenerator.java:80: Note: [ReferenceComparison] Reference comparison should be value comparison
      } else if (schema == SszPrimitiveSchemas.BIT_SCHEMA) {
                        ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/testFixtures/java/tech/pegasys/teku/infrastructure/ssz/RandomSszDataGenerator.java:82: Note: [ReferenceComparison] Reference comparison should be value comparison
      } else if (schema == SszPrimitiveSchemas.BYTE_SCHEMA) {
                        ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/testFixtures/java/tech/pegasys/teku/infrastructure/ssz/RandomSszDataGenerator.java:84: Note: [ReferenceComparison] Reference comparison should be value comparison
      } else if (schema == SszPrimitiveSchemas.UINT64_SCHEMA) {
                        ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/testFixtures/java/tech/pegasys/teku/infrastructure/ssz/RandomSszDataGenerator.java:86: Note: [ReferenceComparison] Reference comparison should be value comparison
      } else if (schema == SszPrimitiveSchemas.UINT256_SCHEMA) {
                        ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/testFixtures/java/tech/pegasys/teku/infrastructure/ssz/RandomSszDataGenerator.java:88: Note: [ReferenceComparison] Reference comparison should be value comparison
      } else if (schema == SszPrimitiveSchemas.BYTES4_SCHEMA) {
                        ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/testFixtures/java/tech/pegasys/teku/infrastructure/ssz/RandomSszDataGenerator.java:90: Note: [ReferenceComparison] Reference comparison should be value comparison
      } else if (schema == SszPrimitiveSchemas.BYTES32_SCHEMA) {
                        ^
/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszListTestBase.java:33: Note: [ReferenceComparison] Reference comparison should be value comparison
    Assumptions.assumeTrue(data.getSchema().getElementSchema() != SszPrimitiveSchemas.BIT_SCHEMA);
                                                               ^
/Users/jtraglia/Projects/jtraglia/teku/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateInvariants.java:80: Note: [ReferenceComparison] Reference comparison should be value comparison
    if (state == obj) {
              ^
/Users/jtraglia/Projects/jtraglia/teku/validator/api/src/main/java/tech/pegasys/teku/validator/api/SyncCommitteeDuty.java:58: Note: [ReferenceComparison] Reference comparison should be value comparison
        && validatorSyncCommitteeIndices == that.validatorSyncCommitteeIndices
                                         ^
/Users/jtraglia/Projects/jtraglia/teku/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/AbstractBeaconStateTest.java:79: Note: [ReferenceComparison] Reference comparison should be value comparison
    assertThat(state == stateCopy).isFalse();
                     ^
/Users/jtraglia/Projects/jtraglia/teku/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/AbstractBeaconStateTest.java:90: Note: [ReferenceComparison] Reference comparison should be value comparison
    assertThat(state == stateCopy).isFalse();
```

</details>

This work is associated with this PR:
* https://github.com/ConsenSys/teku/pull/6457