### PR TITLE
Clean up some things in JavaCase

### DIFF
--- a/src/main/java/tech/pegasys/tools/epchecks/JavaCase.java
+++ b/src/main/java/tech/pegasys/tools/epchecks/JavaCase.java
@@ -45,7 +45,6 @@ public class JavaCase extends BugChecker
     implements MethodTreeMatcher, ClassTreeMatcher, VariableTreeMatcher {
 
   private static final Pattern PATTERN_HAS_LOWER = Pattern.compile("^.*[a-z].*$");
-  private static final Pattern PATTERN_HAS_UPPER = Pattern.compile("^.*[A-Z].*$");
   private static final Pattern PATTERN_STARTS_WITH_LOWER = Pattern.compile("^[a-z].*$");
   private static final Pattern PATTERN_STARTS_WITH_UPPER = Pattern.compile("^[A-Z].*$");
   private static final Pattern PATTERN_UNDERSCORES = Pattern.compile("^_+$");

--- a/src/test/java/tech/pegasys/tools/epchecks/JavaCaseTest.java
+++ b/src/test/java/tech/pegasys/tools/epchecks/JavaCaseTest.java
@@ -26,12 +26,12 @@ public class JavaCaseTest {
   }
 
   @Test
-  public void camelCasePositiveCases() {
+  public void javaCasePositiveCases() {
     compilationHelper.addSourceFile("JavaCasePositiveCases.java").doTest();
   }
 
   @Test
-  public void camelCaseNegativeCases() {
+  public void javaCaseNegativeCases() {
     compilationHelper.addSourceFile("JavaCaseNegativeCases.java").doTest();
   }
 }


### PR DESCRIPTION
Cleans up a few things I noticed:

* The `PATTERN_HAS_UPPER` isn't actually used.
* The test function uses the temporary "camelCase" name.