### PR TITLE
Filter typevar results from MathTargetType

### DIFF
--- a/src/main/java/tech/pegasys/tools/epchecks/MathTargetType.java
+++ b/src/main/java/tech/pegasys/tools/epchecks/MathTargetType.java
@@ -68,7 +68,9 @@ public class MathTargetType extends BugChecker implements MethodInvocationTreeMa
     if (POTENTIALLY_CONFUSED_MATH_FUNC.matches(tree, state)) {
       Tree parent = state.getPath().getParentPath().getLeaf();
       Type type = getTargetType(tree, parent, state, state.getPath().getParentPath());
-      if (type != null && !anyMethodArgIs(tree, state, type.getKind())) {
+      if (type != null
+          && type.getKind() != TypeKind.TYPEVAR
+          && !anyMethodArgIs(tree, state, type.getKind())) {
         String typeName = type.getKind().toString().toLowerCase();
         return buildDescription(tree)
             .setMessage(

--- a/src/test/resources/tech/pegasys/tools/epchecks/MathTargetTypeNegativeCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/MathTargetTypeNegativeCases.java
@@ -15,6 +15,8 @@
 
 package tech.pegasys.tools.epchecks;
 
+import java.util.Optional;
+
 public class MathTargetTypeNegativeCases {
 
     public void expectedInt() {
@@ -50,5 +52,9 @@ public class MathTargetTypeNegativeCases {
         int b = Math.min(0, 1) - 1;
         int c = Math.min(0, 1) / 1;
         int d = Math.min(0, 1) * 1;
+    }
+
+    public void resultIsTypevar() {
+        Optional<Integer> a = Optional.of(Math.min(0, 1));
     }
 }


### PR DESCRIPTION
When running this on Besu, I noticed that the MathTargetType check has a problem. When the "target type" is a typevar, like when used with `Optional#of`, this check reports a false positive.