### PR TITLE
Reimplement DoNotReturnNullOptionals to fix edge case

### DIFF
--- a/src/main/java/tech/pegasys/tools/epchecks/DoNotReturnNullOptionals.java
+++ b/src/main/java/tech/pegasys/tools/epchecks/DoNotReturnNullOptionals.java
@@ -13,56 +13,64 @@
 package tech.pegasys.tools.epchecks;
 
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
-import static com.google.errorprone.matchers.Matchers.contains;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.sun.source.tree.Tree.Kind.NULL_LITERAL;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
-import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.ReturnTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ReturnTree;
 import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Type;
 
-/*
- * This is reworked from an example found at:
- * https://github.com/google/error-prone/wiki/Writing-a-check
- */
-
-@AutoService(BugChecker.class) // the service descriptor
+@AutoService(BugChecker.class)
 @BugPattern(
     name = "DoNotReturnNullOptionals",
     summary = "Do not return null optionals.",
     severity = SUGGESTION,
     linkType = BugPattern.LinkType.NONE)
-public class DoNotReturnNullOptionals extends BugChecker implements MethodTreeMatcher {
+public class DoNotReturnNullOptionals extends BugChecker implements ReturnTreeMatcher {
+  private static final Matcher<Tree> NULL = Matchers.kindIs(NULL_LITERAL);
 
-  private static class ReturnNullMatcher implements Matcher<Tree> {
-
-    @Override
-    public boolean matches(final Tree tree, final VisitorState state) {
-      if ((tree instanceof ReturnTree) && (((ReturnTree) tree).getExpression() != null)) {
-        return ((ReturnTree) tree).getExpression().getKind() == NULL_LITERAL;
-      }
-      return false;
+  @Override
+  public Description matchReturn(final ReturnTree tree, final VisitorState state) {
+    if (tree == null || !NULL.matches(tree.getExpression(), state)) {
+      return NO_MATCH;
     }
+    final Type returnType = getReturnType(state);
+    if (returnType != null && isOptional(returnType)) {
+      return describeMatch(tree);
+    }
+    return NO_MATCH;
   }
 
-  private static final Matcher<Tree> RETURN_NULL = new ReturnNullMatcher();
-  private static final Matcher<Tree> CONTAINS_RETURN_NULL = contains(RETURN_NULL);
-
-  @SuppressWarnings("TreeToString")
-  @Override
-  public Description matchMethod(final MethodTree tree, final VisitorState state) {
-    if ((tree.getReturnType() == null)
-        || !tree.getReturnType().toString().startsWith("Optional<")
-        || (tree.getBody() == null)
-        || (!CONTAINS_RETURN_NULL.matches(tree.getBody(), state))) {
-      return Description.NO_MATCH;
+  // This logic comes from the IntLongMath check:
+  // https://github.com/google/error-prone/blob/5391186274d64031b5536a3e95fc1750711fb4b2/core/src/main/java/com/google/errorprone/bugpatterns/IntLongMath.java#L50-L72
+  private static Type getReturnType(final VisitorState state) {
+    Type type = null;
+    outer:
+    for (Tree parent : state.getPath()) {
+      switch (parent.getKind()) {
+        case METHOD:
+          type = ASTHelpers.getType(((MethodTree) parent).getReturnType());
+          break outer;
+        case LAMBDA_EXPRESSION:
+          type = state.getTypes().findDescriptorType(ASTHelpers.getType(parent)).getReturnType();
+          break outer;
+        default: // fall out
+      }
     }
-    return describeMatch(tree);
+    return type;
+  }
+
+  private static boolean isOptional(final Type type) {
+    return type.toString().startsWith("java.util.Optional<");
   }
 }

--- a/src/main/java/tech/pegasys/tools/epchecks/DoNotReturnNullOptionals.java
+++ b/src/main/java/tech/pegasys/tools/epchecks/DoNotReturnNullOptionals.java
@@ -37,13 +37,16 @@ import com.sun.tools.javac.code.Type;
     severity = SUGGESTION,
     linkType = BugPattern.LinkType.NONE)
 public class DoNotReturnNullOptionals extends BugChecker implements ReturnTreeMatcher {
-  private static final Matcher<Tree> NULL = Matchers.kindIs(NULL_LITERAL);
+  private static final Matcher<Tree> IS_NULL_LITERAL = Matchers.kindIs(NULL_LITERAL);
 
   @Override
   public Description matchReturn(final ReturnTree tree, final VisitorState state) {
-    if (tree == null || !NULL.matches(tree.getExpression(), state)) {
+    // Filter out statements that do not return null.
+    if (tree == null || !IS_NULL_LITERAL.matches(tree.getExpression(), state)) {
       return NO_MATCH;
     }
+
+    // If the return type is an optional, it's match.
     final Type returnType = getReturnType(state);
     if (returnType != null && isOptional(returnType)) {
       return describeMatch(tree);
@@ -64,7 +67,8 @@ public class DoNotReturnNullOptionals extends BugChecker implements ReturnTreeMa
         case LAMBDA_EXPRESSION:
           type = state.getTypes().findDescriptorType(ASTHelpers.getType(parent)).getReturnType();
           break outer;
-        default: // fall out
+        default:
+          // Fall out.
       }
     }
     return type;

--- a/src/test/resources/tech/pegasys/tools/epchecks/DoNotReturnNullOptionalsNegativeCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/DoNotReturnNullOptionalsNegativeCases.java
@@ -14,7 +14,10 @@
  */
 package tech.pegasys.tools.epchecks;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 public class DoNotReturnNullOptionalsNegativeCases {
@@ -32,5 +35,16 @@ public class DoNotReturnNullOptionalsNegativeCases {
   @Nullable
   public Optional<Long> returnsNullButAnnotatedWithNullable() {
     return Optional.empty();
+  }
+
+  public Optional<List<Integer>> anonFuncReturnsNull() {
+    final List<Integer> list = List.of(1, 2, 3);
+    return Optional.of(
+        list.stream().map(n -> {
+          if (n == 2) {
+            return null;
+          }
+          return n;
+        }).collect(Collectors.toList()));
   }
 }

--- a/src/test/resources/tech/pegasys/tools/epchecks/DoNotReturnNullOptionalsPositiveCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/DoNotReturnNullOptionalsPositiveCases.java
@@ -19,15 +19,14 @@ import java.util.Optional;
 
 public class DoNotReturnNullOptionalsPositiveCases {
 
-  // BUG: Diagnostic contains: Do not return null optionals.
   public Optional<Long> returnsNull() {
+    // BUG: Diagnostic contains: Do not return null optionals.
     return null;
   }
 
-  // BUG: Diagnostic contains: Do not return null optionals.
   public Optional<Long> sometimesReturnsNull(boolean random) {
     if (random) {
-
+      // BUG: Diagnostic contains: Do not return null optionals.
       return null;
     }
     return Optional.of(2L);


### PR DESCRIPTION
When running this check on Web3Signer, I discovered an edge case. If there's a `return null` expression in an anonymous function, it will incorrectly result in a false positive. I've added an extra test case that demonstrates it.

To fix this, I decided to reimplement the check in a way that makes more sense to me. Instead of matching each method and checking if it contains a null return, instead find all of the null returns and check if the return value is an optional value.

Also, the edge case method in Web3Signer:
* https://github.com/ConsenSys/web3signer/blob/9bae3367671357560151601749ff73173103e02a/signing/src/main/java/tech/pegasys/web3signer/signing/KeystoreFileManager.java#L99-L140