### PR TITLE
Identify non-literal cases of null optionals

### DIFF
--- a/src/test/resources/tech/pegasys/tools/epchecks/DoNotReturnNullOptionalsNegativeCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/DoNotReturnNullOptionalsNegativeCases.java
@@ -47,4 +47,9 @@ public class DoNotReturnNullOptionalsNegativeCases {
           return n;
         }).collect(Collectors.toList()));
   }
+
+  public Optional<Long> returnsVarInConditional(final boolean flag) {
+    Optional<Long> var = flag ? Optional.of(2L) : Optional.of(3L);
+    return var;
+  }
 }

--- a/src/test/resources/tech/pegasys/tools/epchecks/DoNotReturnNullOptionalsPositiveCases.java
+++ b/src/test/resources/tech/pegasys/tools/epchecks/DoNotReturnNullOptionalsPositiveCases.java
@@ -31,4 +31,16 @@ public class DoNotReturnNullOptionalsPositiveCases {
     }
     return Optional.of(2L);
   }
+
+  public Optional<Long> returnsVarAssignedNull() {
+    Optional<Long> var = null;
+    // BUG: Diagnostic contains: Do not return null optionals.
+    return var;
+  }
+
+  public Optional<Long> returnsVarMaybeAssignedNull(final boolean flag) {
+    Optional<Long> var = flag ? Optional.of(2L) : null;
+    // BUG: Diagnostic contains: Do not return null optionals.
+    return var;
+  }
 }


### PR DESCRIPTION
So this was pretty fun to figure out. There are some data flow analysis tools in error-prone that I was able to use. I discovered [`NullnessAnalysis`](http://errorprone.info/api/latest/com/google/errorprone/dataflow/nullnesspropagation/NullnessAnalysis.html) but it was only able to identify cases where the return variable was initialized to null without any conditionals. This has to do with how it treats some values as nullable. Eventually, I discovered [`TrustingNullnessAnalysis`](http://errorprone.info/api/latest/com/google/errorprone/dataflow/nullnesspropagation/TrustingNullnessAnalysis.html) and this worked like I wanted it to. From there, it was simple.

Also, I reversed the checks so that the method return type is checked first. I think this is the simpler/faster check now. No need to do data flow analysis if we don't have to.

Also also, there were no new findings in Teku, which probably means it's pretty good about false positives.