### PR TITLE
Fix JReleaser publish failure due to JGit version conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '21'
@@ -32,6 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '21'

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+    configurations.classpath {
+        // Force JGit 6.x to resolve conflict between git-versioning (7.x) and JReleaser (5.x)
+        // JGit 7.x removed GpgObjectSigner which JReleaser still references
+        // See: https://github.com/jreleaser/jreleaser/discussions/1897
+        resolutionStrategy.force 'org.eclipse.jgit:org.eclipse.jgit:6.10.0.202406032230-r'
+    }
+}
+
 plugins {
     id 'java-library'
     id 'maven-publish'


### PR DESCRIPTION
## Summary
- Fix `ClassNotFoundException: org.eclipse.jgit.lib.GpgObjectSigner` during `jreleaserFullRelease`
- Force JGit 6.10.0 in buildscript classpath to resolve version conflict between git-versioning plugin (JGit 7.x) and JReleaser (JGit 5.x)
- JGit 7.x removed `GpgObjectSigner` which JReleaser still references

See: https://github.com/jreleaser/jreleaser/discussions/1897

## Test plan
- [x] `./gradlew clean build` passes all tests
- [ ] Verify publish workflow succeeds on tag push

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes build/release tooling and dependency resolution; could affect versioning/publish behavior but does not touch runtime/library code.
> 
> **Overview**
> Fixes release/publish failures caused by a JGit version mismatch between `me.qoomon.git-versioning` and `org.jreleaser` by forcing `org.eclipse.jgit` to `6.10.0` in the Gradle `buildscript` classpath.
> 
> Updates the GitHub Actions workflow to check out the full git history (`fetch-depth: 0`) for both `build` and tag-based `publish` jobs, improving version/tag discovery during CI and release runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a208131d310b0cd33a4fcdd17dfd3b4610f01fd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->